### PR TITLE
Update how to set authorization with Faraday

### DIFF
--- a/lib/milkbottle/client.rb
+++ b/lib/milkbottle/client.rb
@@ -60,9 +60,9 @@ module Milkbottle
         http.headers[:content_type] = "application/json"
         http.headers[:user_agent] = user_agent
         if token_authenticated?
-          http.authorization('Bearer', @jwt_token.encode(external_auth_key))
+          http.headers[:authorization] = "Bearer #{@jwt_token.encode(external_auth_key)}"
         elsif anonymous_authenticated?
-          http.authorization('Bearer', @anonymous_token)
+          http.headers[:authorization] = "Bearer #{@anonymous_token}"
           http.headers['X-MILK-API-KEY'] = @api_key
         elsif app_authenticated?
           http.headers['X-MILK-API-KEY'] = @api_key

--- a/lib/milkbottle/version.rb
+++ b/lib/milkbottle/version.rb
@@ -1,3 +1,3 @@
 module Milkbottle
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
With the upgrade of Faraday to 2.0 (with the change to Ruby 3), the authentication helper methods in Connection were been removed.